### PR TITLE
Increased stats update rate

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -78,33 +78,31 @@ let utils = {
 
         self.curl.stderr.on("data", data => {
             data = data.toString('ascii');
-            if (data.indexOf("#") === -1) {
-                if (Norespond) {
-                    data = data.toString('ascii');
-                    if (/\d+(\.\d{1,2})/.test(data)) {
-                        if (!already) {
-                            self.emit("start");
-                        }
-
-                        let dataWritten = utils.getFilesize(self.filePath),
-                            size = self.fileinfo.filesize,
-                            pr = parseFloat((dataWritten * 100) / size).toFixed(1);
-
-                        progress = pr;
-
-                        now = { time: new Date().getTime() / 1000, data: dataWritten };
-                        let diff = now.time - previous.time
-                        if (diff !== 0) {
-                            speed = Math.floor((((now.data - previous.data) / (now.time - previous.time)) / 1024))
-                        }
-                        previous = utils.xtend({}, now);
-
-                        self.emit("progress", { progress: pr, dataWritten: dataWritten, filesize: size, speed: `${speed}KB/s` });
-                        already = true;
+            if (Norespond) {
+                data = data.toString('ascii');
+                if (/\d+(\.\d{1,2})/.test(data)) {
+                    if (!already) {
+                        self.emit("start");
                     }
-                } else {
-                    Norespond = true;
+
+                    let dataWritten = utils.getFilesize(self.filePath),
+                        size = self.fileinfo.filesize,
+                        pr = parseFloat((dataWritten * 100) / size).toFixed(1);
+
+                    progress = pr;
+
+                    now = { time: new Date().getTime() / 1000, data: dataWritten };
+                    let diff = now.time - previous.time
+                    if (diff !== 0) {
+                        speed = Math.floor((((now.data - previous.data) / (now.time - previous.time)) / 1024))
+                    }
+                    previous = utils.xtend({}, now);
+
+                    self.emit("progress", { progress: pr, dataWritten: dataWritten, filesize: size, speed: `${speed}KB/s` });
+                    already = true;
                 }
+            } else {
+                Norespond = true;
             }
         });
 


### PR DESCRIPTION
Hey. I removed check for `data.indexOf('#') === -1` on `data` event, forcing stats to update every time there's any output from curl (even if it's just a bunch of hash signs). Anyways, this handler uses fs to update `stats.progress` instead of the actual curl output. The reason for this is that stats seem to decrease update rate as the download progresses (tested on small ~100MB files), making updates rapid (40% -> 85% -> 100%).

BTW, I used 1.2.7, because 1.2.8 seems to be broken.